### PR TITLE
auto generate distinct uuids; fallback to System Settings

### DIFF
--- a/profiles/deferral-90days.mobileconfig
+++ b/profiles/deferral-90days.mobileconfig
@@ -8,7 +8,7 @@
       <key>PayloadType</key><string>com.apple.applicationaccess</string>
       <key>PayloadVersion</key><integer>1</integer>
       <key>PayloadIdentifier</key><string>org.stayonsequoia.restrictions</string>
-      <key>PayloadUUID</key><string>REPLACE-WITH-UUID</string>
+      <key>PayloadUUID</key><string>PAYLOAD-UUID</string>
       <key>PayloadEnabled</key><true/>
       <key>PayloadDisplayName</key><string>Software Update Deferrals</string>
 
@@ -26,7 +26,7 @@
   <key>PayloadType</key><string>Configuration</string>
   <key>PayloadVersion</key><integer>1</integer>
   <key>PayloadIdentifier</key><string>org.stayonsequoia.profile</string>
-  <key>PayloadUUID</key><string>REPLACE-WITH-UUID</string>
+  <key>PayloadUUID</key><string>PROFILE-UUID</string>
   <key>PayloadDisplayName</key><string>Stay on Sequoia: Update Deferrals</string>
   <key>PayloadOrganization</key><string>StayOnSequoia Community</string>
 </dict>

--- a/scripts/install-profile.sh
+++ b/scripts/install-profile.sh
@@ -7,8 +7,26 @@ if [[ ! -f "$PROFILE" ]]; then
   exit 1
 fi
 
+# Generate two distinct UUIDs
+UUID1=$(uuidgen)
+UUID2=$(uuidgen)
+
+# Create profile with UUIDs inserted
+TEMP_DIR=$(mktemp -d)
+TEMP_PROFILE="$TEMP_DIR/profile.mobileconfig"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+sed -e "s/PAYLOAD-UUID/$UUID1/" -e "s/PROFILE-UUID/$UUID2/" "$PROFILE" > "$TEMP_PROFILE"
+
 echo "Installing profile: $PROFILE"
-# macOS still ships the `profiles` CLI; use the UI if this fails.
-sudo /usr/bin/profiles install -type configuration -path "$PROFILE" \
-  || open "$PROFILE"
-echo "Done. You may need to open System Settings → Privacy & Security → Profiles to approve."
+echo "  Payload UUID: $UUID1"
+echo "  Profile UUID: $UUID2"
+
+# Try CLI first; fall back to UI if it fails
+if sudo /usr/bin/profiles install -type configuration -path "$TEMP_PROFILE" 2>/dev/null; then
+  echo "Done. Check System Settings → Privacy & Security → Profiles to verify."
+else
+  echo "Opening profile in System Settings for manual approval..."
+  open "$TEMP_PROFILE"
+  echo "Press Enter after you've approved (or declined) the profile in System Settings."
+  read -r
+fi


### PR DESCRIPTION
**Purpose and expected outcome**
The install script now auto-generates two distinct UUIDs at install time, inserting them into the mobileconfig template. This allows the same profile to be reinstalled with fresh UUIDs (e.g., after the 90-day deferral expires) without manually editing the file.

**Supported macOS versions tested**

- macOS 15.7.3 (Sequoia)

**Known limitations or side effects**

- The profiles install CLI may report success but not actually install; the script falls back to opening System Settings for manual approval
- The temp file must persist until the user completes approval in System Settings; the script waits for Enter before cleanup
- Requires uuidgen (ships with macOS)

**How to disable or undo**

- Revert `install-profile.sh`and `deferral-90days.mobileconfig` to use hardcoded UUIDs instead of placeholders.