### PR TITLE
Fix: remove minor/non-OS update deferrals that suppress all macOS updates

### DIFF
--- a/profiles/deferral-90days.mobileconfig
+++ b/profiles/deferral-90days.mobileconfig
@@ -16,10 +16,6 @@
       <key>forceDelayedMajorSoftwareUpdates</key><true/>
       <key>enforcedSoftwareUpdateMajorOSDeferredInstallDelay</key><integer>90</integer>
 
-      <!-- Optional (set to your taste) -->
-      <key>forceDelayedSoftwareUpdates</key><true/>
-      <key>enforcedSoftwareUpdateMinorOSDeferredInstallDelay</key><integer>30</integer>
-      <key>enforcedSoftwareUpdateNonOSDeferredInstallDelay</key><integer>30</integer>
     </dict>
   </array>
 


### PR DESCRIPTION
## Summary

The `deferral-90days.mobileconfig` profile included three \"optional\" keys that in practice block **all** macOS updates — not just major upgrades (Sequoia → Tahoe):

- `forceDelayedSoftwareUpdates`
- `enforcedSoftwareUpdateMinorOSDeferredInstallDelay` (30 days)
- `enforcedSoftwareUpdateNonOSDeferredInstallDelay` (30 days)

Users installing this profile find that minor Sequoia updates (e.g. 15.7.x security patches) are also hidden from System Settings, with no \"Update Now\" button visible. This is not the intended behaviour — the goal is to block Tahoe, not suppress security updates.

## Fix

Removed the three keys above. The profile now only sets:

- `forceDelayedMajorSoftwareUpdates: true`
- `enforcedSoftwareUpdateMajorOSDeferredInstallDelay: 90`

Minor and non-OS updates are unaffected.

## Tested on

- macOS Sequoia 15.7.4 (24G517)
- Profile validated with `plutil -lint` ✅
- After reinstalling the corrected profile, minor update prompts reappeared in System Settings ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)